### PR TITLE
Removes Duplicate Colors and Fixes colorsHelper test

### DIFF
--- a/src/Helpers/colorsHelper.js
+++ b/src/Helpers/colorsHelper.js
@@ -12,7 +12,9 @@ export const loadColors = (productType) => {
     productType.forEach((product) => {
         product.product_colors.forEach(color => {
             if (color.colour_name) {
-                productColors.push(color.colour_name.trim());
+                if(!productColors.includes(color.colour_name)) {
+                    productColors.push(color.colour_name.trim());
+                }
                 allColors[formatColorName(color.colour_name)] = {
                     product,
                     hexcode: color.hex_value,

--- a/src/Helpers/colorsHelper.test.js
+++ b/src/Helpers/colorsHelper.test.js
@@ -22,7 +22,7 @@ describe('formatColorName', () => {
         ]
         const expected = {
             allColors: {"casablanca": {"hexcode": "#444446", "product": {"id": 1036, "product_colors": [{"colour_name": "Casablanca", "hex_value": "#444446"}, {"colour_name": "Evrest", "hex_value": "#6B7475"}, {"colour_name": "Sahara", "hex_value": "#966A54"}]}}, "evrest": {"hexcode": "#6B7475", "product": {"id": 1036, "product_colors": [{"colour_name": "Casablanca", "hex_value": "#444446"}, {"colour_name": "Evrest", "hex_value": "#6B7475"}, {"colour_name": "Sahara", "hex_value": "#966A54"}]}}, "sahara": {"hexcode": "#966A54", "product": {"id": 1036, "product_colors": [{"colour_name": "Casablanca", "hex_value": "#444446"}, {"colour_name": "Evrest", "hex_value": "#6B7475"}, {"colour_name": "Sahara", "hex_value": "#966A54"}]}}},
-            productColors: ["Casablanca", "Casablanca", "Casablanca", "Evrest", "Evrest", "Evrest", "Sahara", "Sahara", "Sahara"],
+            productColors: ["Casablanca", "Evrest", "Sahara" ],
         }
         const result = loadColors(mockProductType)
         expect(result).toEqual(expected)


### PR DESCRIPTION
-Puts in logic in colorsHelper.js to account for duplicate colors.
*Works for Eyeshadow and Nailpolish, but still some duplicate colors in Lipstick and Blush

-Updates colorsHelper.js.test file